### PR TITLE
Add Torque unit class with angle-aware dimensionality

### DIFF
--- a/Measurement/Factories/Metric.cs
+++ b/Measurement/Factories/Metric.cs
@@ -7,12 +7,18 @@ public class Metric
     public readonly string Prefix;
     public readonly double Factor;
 
+    /// <summary>
+    /// Creates a metric prefix with the given symbol prefix and multiplicative factor.
+    /// </summary>
     public Metric(string prefix, double factor)
     {
         Prefix = prefix;
         Factor = factor;
     }
 
+    /// <summary>
+    /// Applies this metric prefix to a unit, returning a new scaled unit with the prefix prepended to the symbol.
+    /// </summary>
     public UnitOfMeasure Create(UnitOfMeasure unitOfMeasure)
     {
         return UnitFactory.Create(this, unitOfMeasure);

--- a/Measurement/Units/Torque.cs
+++ b/Measurement/Units/Torque.cs
@@ -1,0 +1,45 @@
+using Measurement.BaseClasses;
+using Measurement.Factories;
+using Uom = Measurement.Models.UnitOfMeasure;
+
+namespace Measurement.Units;
+
+// Torque (M·L²·Θ·t⁻²) — dimensionally distinct from energy (M·L²·t⁻²) because
+// torque is the rate of change of angular momentum (which carries the angle dimension).
+// The Radian factor in each definition is what separates torque from energy in this system.
+// Additional metric prefix variants can be added using the Metric.k/M/m/micro etc. pattern.
+public class Torque : ReflectiveUnitList<Torque>
+{
+    private Torque() { }
+    public static readonly Torque Units = new();
+
+    // SI
+    public static readonly Uom NewtonMeter = UnitFactory.Create(
+        "N·m",
+        (Force.Newton, 1),
+        (Length.Meter, 1),
+        (Angle.Radian, 1));
+
+    public static readonly Uom KilonewtonMeter = Metric.k(NewtonMeter);
+    public static readonly Uom MillinewtonMeter = Metric.m(NewtonMeter);
+
+    // English Engineering
+    public static readonly Uom PoundForceFoot = UnitFactory.Create(
+        "lbf·ft",
+        (Force.PoundForce, 1),
+        (Length.Foot, 1),
+        (Angle.Radian, 1));
+
+    public static readonly Uom PoundForceInch = UnitFactory.Create(
+        "lbf·in",
+        (Force.PoundForce, 1),
+        (Length.Inch, 1),
+        (Angle.Radian, 1));
+
+    // Common in small motors and electronics
+    public static readonly Uom OunceForceInch = UnitFactory.Create(
+        "ozf·in",
+        (Force.OunceForce, 1),
+        (Length.Inch, 1),
+        (Angle.Radian, 1));
+}


### PR DESCRIPTION
## Summary

- Adds `Torque.cs` with units N·m, kN·m, mN·m, lbf·ft, lbf·in, and ozf·in
- Torque is defined with dimensions **M·L²·Θ·t⁻²** — distinct from energy (M·L²·t⁻²) — by including `Angle.Radian` in each composite unit definition
- Adds XML doc comments to the `Metric` constructor and instance `Create` method, completing docstring coverage of that class

## Why angle in the numerator?

Torque is the rate of change of angular momentum (τ = dL/dt). Since `AngularMomentum` in this codebase is built from `MomentOfInertia × AngularVelocity`, and `AngularVelocity` carries the angle dimension (Θ·t⁻¹), angular momentum has dimension M·L²·Θ·t⁻¹ — and therefore torque has M·L²·Θ·t⁻². This keeps torque dimensionally distinct from energy, which is the right behavior: you can't accidentally add a torque to a joule.

## Test plan

- [x] Solution builds with 0 errors
- [x] All 65 existing tests pass
- [ ] Verify `Torque.NewtonMeter.Dimensionality` ≠ `Energy.Joule.Dimensionality` in a test

🤖 Generated with [Claude Code](https://claude.com/claude-code)