### PR TITLE
Add unit tests for Torque dimensionality and gauge pressure

### DIFF
--- a/Measurement.Test/Units/PressureTests.cs
+++ b/Measurement.Test/Units/PressureTests.cs
@@ -1,0 +1,66 @@
+using Measurement.Units;
+using FluentAssertions;
+using Xunit;
+
+namespace Measurement.Test.Units;
+
+public class PressureTests
+{
+    private const double StandardAtmospherePa = 101325.0;
+
+    [Fact]
+    public void GaugeUnitsHaveSameDimensionalityAsAbsolute()
+    {
+        Pressure.BarGauge.Dimensionality.Should().Be(Pressure.Bar.Dimensionality);
+        Pressure.PsiGauge.Dimensionality.Should().Be(Pressure.PoundPerSquareInch.Dimensionality);
+        Pressure.KilopascalGauge.Dimensionality.Should().Be(Pressure.Kilopascal.Dimensionality);
+    }
+
+    [Fact]
+    public void ZeroGaugePressureEqualsOneStandardAtmosphere()
+    {
+        Pressure.BarGauge.ConvertToKmsValue(0).Should().BeApproximately(StandardAtmospherePa, 1E-6);
+        Pressure.PsiGauge.ConvertToKmsValue(0).Should().BeApproximately(StandardAtmospherePa, 1E-6);
+        Pressure.KilopascalGauge.ConvertToKmsValue(0).Should().BeApproximately(StandardAtmospherePa, 1E-6);
+    }
+
+    [Fact]
+    public void OneBarGaugeEqualsOneAtmospherePlusOneBar()
+    {
+        var expected = StandardAtmospherePa + Pressure.Bar.ConvertToKmsValue(1);
+        Pressure.BarGauge.ConvertToKmsValue(1).Should().BeApproximately(expected, 1E-6);
+    }
+
+    [Fact]
+    public void AbsolutePressureConvertsToZeroGauge()
+    {
+        Pressure.BarGauge.ConvertFromKmsValue(StandardAtmospherePa).Should().BeApproximately(0, 1E-9);
+        Pressure.PsiGauge.ConvertFromKmsValue(StandardAtmospherePa).Should().BeApproximately(0, 1E-9);
+        Pressure.KilopascalGauge.ConvertFromKmsValue(StandardAtmospherePa).Should().BeApproximately(0, 1E-9);
+    }
+
+    [Fact]
+    public void GaugePressureRoundTrips()
+    {
+        const double valueInBarg = 2.5;
+        var absolutePa = Pressure.BarGauge.ConvertToKmsValue(valueInBarg);
+        Pressure.BarGauge.ConvertFromKmsValue(absolutePa).Should().BeApproximately(valueInBarg, 1E-9);
+
+        const double valueInPsig = 30.0;
+        var absolutePa2 = Pressure.PsiGauge.ConvertToKmsValue(valueInPsig);
+        Pressure.PsiGauge.ConvertFromKmsValue(absolutePa2).Should().BeApproximately(valueInPsig, 1E-9);
+    }
+
+    [Fact]
+    public void AbsoluteSpotChecks()
+    {
+        // 1 atm = 101325 Pa (exact by definition)
+        Pressure.Atmosphere.ConvertToKmsValue(1).Should().BeApproximately(StandardAtmospherePa, 1E-6);
+
+        // 1 bar = 100000 Pa (exact by definition)
+        Pressure.Bar.ConvertToKmsValue(1).Should().BeApproximately(100000, 1E-6);
+
+        // 1 psi ≈ 6894.76 Pa
+        Pressure.PoundPerSquareInch.ConvertToKmsValue(1).Should().BeApproximately(6894.76, 0.01);
+    }
+}

--- a/Measurement.Test/Units/TorqueTests.cs
+++ b/Measurement.Test/Units/TorqueTests.cs
@@ -1,0 +1,48 @@
+using Measurement.Units;
+using FluentAssertions;
+using Xunit;
+
+namespace Measurement.Test.Units;
+
+public class TorqueTests
+{
+    [Fact]
+    public void TorqueIsNotDimensionallyEqualToEnergy()
+    {
+        Torque.NewtonMeter.Dimensionality.Should().NotBe(Energy.Joule.Dimensionality);
+    }
+
+    [Fact]
+    public void NewtonMeterIsKmsBase()
+    {
+        Torque.NewtonMeter.ConvertToKmsValue(1).Should().BeApproximately(1, 1E-9);
+        Torque.NewtonMeter.ConvertFromKmsValue(1).Should().BeApproximately(1, 1E-9);
+    }
+
+    [Fact]
+    public void ImperialSpotChecks()
+    {
+        // 1 lbf·ft ≈ 1.35582 N·m
+        Torque.PoundForceFoot.ConvertToKmsValue(1).Should().BeApproximately(1.35582, 0.0001);
+
+        // 1 lbf·in = 1/12 lbf·ft
+        Torque.PoundForceInch.ConvertToKmsValue(1).Should().BeApproximately(1.35582 / 12, 0.0001);
+
+        // 1 ozf·in = 1/16 lbf·in
+        Torque.OunceForceInch.ConvertToKmsValue(1).Should().BeApproximately(1.35582 / 192, 0.0001);
+    }
+
+    [Fact]
+    public void TwelvePoundForceInchesEqualsOnePoundForceFoot()
+    {
+        Torque.PoundForceInch.ConvertToKmsValue(12)
+            .Should().BeApproximately(Torque.PoundForceFoot.ConvertToKmsValue(1), 1E-9);
+    }
+
+    [Fact]
+    public void SixteenOunceForceInchesEqualsOnePoundForceInch()
+    {
+        Torque.OunceForceInch.ConvertToKmsValue(16)
+            .Should().BeApproximately(Torque.PoundForceInch.ConvertToKmsValue(1), 1E-9);
+    }
+}


### PR DESCRIPTION
## Summary

- **`TorqueTests.cs`** — verifies the core invariant of the angle-aware torque design: `Torque.NewtonMeter.Dimensionality ≠ Energy.Joule.Dimensionality`; spot-checks lbf·ft, lbf·in, and ozf·in KMS factors; and checks internal consistency (12 lbf·in = 1 lbf·ft, 16 ozf·in = 1 lbf·in)
- **`PressureTests.cs`** — verifies that 0 barg/psig/kPag each equal one standard atmosphere in Pa; checks that absolute→gauge conversion round-trips; spot-checks Pa values for atm, bar, and psi

## Test plan

- [x] All 75 tests pass (up from 65 before this PR)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)