### PR TITLE
Milestone 2.5: uncertainty-aware inequality operators

### DIFF
--- a/DimensionedExpression.Test/BinaryOperators/InequalityOperatorTests.cs
+++ b/DimensionedExpression.Test/BinaryOperators/InequalityOperatorTests.cs
@@ -1,0 +1,286 @@
+using DimensionedExpression.BinaryOperators;
+using DimensionedExpression.Expressions;
+using FluentAssertions;
+using Measurement;
+using Measurement.Uncertainty;
+using Measurement.Units;
+using Xunit;
+
+namespace DimensionedExpression.Test.BinaryOperators;
+
+public class InequalityOperatorTests
+{
+    private static MagnitudeVariable Symmetric(double kmsValue, double relativeError = 0) =>
+        new("x", new Magnitude(kmsValue, Mass.Kilogram, relativeError));
+
+    private static MagnitudeVariable Asymmetric(double kmsValue, double upperError, double lowerError) =>
+        new("x", new Magnitude(new Quantity(kmsValue, Mass.Kilogram), new BoundedUncertainty(upperError, lowerError)));
+
+    private static MagnitudeVariable Unbound() =>
+        new("x", Mass.Kilogram.Dimensionality);
+
+    private static DefinitelyLessThanOperator DefLess(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+    private static UpperBoundsLessThanOperator UpperLess(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+    private static NominallyLessThanOperator NomLess(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+    private static DefinitelyGreaterThanOperator DefGreater(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+    private static LowerBoundsGreaterThanOperator LowerGreater(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+    private static NominallyGreaterThanOperator NomGreater(MagnitudeVariable lhs, MagnitudeVariable rhs) =>
+        new() { Id = "t", Lhs = lhs, Rhs = rhs };
+
+    // ── Null / not-fully-described ────────────────────────────────────────────
+
+    [Fact]
+    public void AllOperators_ReturnNull_WhenLhsIsUnbound()
+    {
+        var rhs = Symmetric(10, 0.1);
+        DefLess(Unbound(), rhs).IsSatisfied().Should().BeNull();
+        UpperLess(Unbound(), rhs).IsSatisfied().Should().BeNull();
+        NomLess(Unbound(), rhs).IsSatisfied().Should().BeNull();
+        DefGreater(Unbound(), rhs).IsSatisfied().Should().BeNull();
+        LowerGreater(Unbound(), rhs).IsSatisfied().Should().BeNull();
+        NomGreater(Unbound(), rhs).IsSatisfied().Should().BeNull();
+    }
+
+    [Fact]
+    public void AllOperators_ReturnNull_WhenRhsIsUnbound()
+    {
+        var lhs = Symmetric(10, 0.1);
+        DefLess(lhs, Unbound()).IsSatisfied().Should().BeNull();
+        UpperLess(lhs, Unbound()).IsSatisfied().Should().BeNull();
+        NomLess(lhs, Unbound()).IsSatisfied().Should().BeNull();
+        DefGreater(lhs, Unbound()).IsSatisfied().Should().BeNull();
+        LowerGreater(lhs, Unbound()).IsSatisfied().Should().BeNull();
+        NomGreater(lhs, Unbound()).IsSatisfied().Should().BeNull();
+    }
+
+    // ── DefinitelyLessThanOperator (<<) ──────────────────────────────────────
+    // Lhs.Upper < Rhs.Lower: entire intervals non-overlapping
+
+    [Fact]
+    public void DefinitelyLessThan_ClearGap_IsTrue()
+    {
+        // Lhs: 5 ± 10% → upper = 5.5;  Rhs: 10 ± 10% → lower = 9
+        // 5.5 < 9 → true
+        DefLess(Symmetric(5, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DefinitelyLessThan_IntervalsOverlap_IsFalse()
+    {
+        // Lhs: 9 ± 10% → upper = 9.9;  Rhs: 10 ± 10% → lower = 9
+        // 9.9 < 9 → false
+        DefLess(Symmetric(9, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void DefinitelyLessThan_LhsGreaterThanRhs_IsFalse()
+    {
+        DefLess(Symmetric(10, 0), Symmetric(5, 0))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void DefinitelyLessThan_AsymmetricBounds_UsesDirectionalErrors()
+    {
+        // Lhs: 5 kg, upperError=1 → upper=6;  Rhs: 10 kg, lowerError=2 → lower=8
+        // 6 < 8 → true
+        DefLess(Asymmetric(5, 1.0, 0.5), Asymmetric(10, 0.5, 2.0))
+            .IsSatisfied().Should().BeTrue();
+
+        // Lhs: 5 kg, upperError=3 → upper=8;  same Rhs lower=8
+        // 8 < 8 → false (strict)
+        DefLess(Asymmetric(5, 3.0, 0.5), Asymmetric(10, 0.5, 2.0))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    // ── UpperBoundsLessThanOperator (<^) ─────────────────────────────────────
+    // Lhs.Upper < Rhs.Upper: ceilings compared; intervals may overlap
+
+    [Fact]
+    public void UpperBoundsLessThan_OverlappingIntervals_CanBeTrue()
+    {
+        // Lhs: 9 ± 10% → upper=9.9;  Rhs: 10 ± 10% → upper=11
+        // intervals overlap ([8.1,9.9] vs [9,11]), but 9.9 < 11 → true
+        UpperLess(Symmetric(9, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpperBoundsLessThan_LhsUpperExceedsRhsUpper_IsFalse()
+    {
+        // Lhs: 11 ± 10% → upper=12.1;  Rhs: 10 ± 10% → upper=11
+        // 12.1 < 11 → false
+        UpperLess(Symmetric(11, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpperBoundsLessThan_IsWeakerThanDefinitely()
+    {
+        // This case passes UpperBounds but fails Definitely:
+        // Lhs: 9 ± 10% → upper=9.9, Rhs: 10 ± 10% → lower=9, upper=11
+        // DefinitelyLessThan: 9.9 < 9 → false
+        // UpperBoundsLessThan: 9.9 < 11 → true
+        var lhs = Symmetric(9, 0.1);
+        var rhs = Symmetric(10, 0.1);
+        DefLess(lhs, rhs).IsSatisfied().Should().BeFalse();
+        UpperLess(lhs, rhs).IsSatisfied().Should().BeTrue();
+    }
+
+    // ── NominallyLessThanOperator (<~) ───────────────────────────────────────
+    // Lhs.KmsValue < Rhs.KmsValue: nominal values only, uncertainty ignored
+
+    [Fact]
+    public void NominallyLessThan_LargeOverlappingErrors_IgnoresUncertainty()
+    {
+        // Lhs: 9 ± 50% → [4.5, 13.5];  Rhs: 10 ± 50% → [5, 15]
+        // Intervals heavily overlap, but 9 < 10 → true
+        NomLess(Symmetric(9, 0.5), Symmetric(10, 0.5))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void NominallyLessThan_NominalReversed_IsFalse()
+    {
+        NomLess(Symmetric(10, 0), Symmetric(9, 0))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void NominallyLessThan_EqualNominals_IsFalse()
+    {
+        NomLess(Symmetric(10, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    // ── DefinitelyGreaterThanOperator (>>) ───────────────────────────────────
+    // Lhs.Lower > Rhs.Upper: entire intervals non-overlapping
+
+    [Fact]
+    public void DefinitelyGreaterThan_ClearGap_IsTrue()
+    {
+        // Lhs: 10 ± 10% → lower=9;  Rhs: 5 ± 10% → upper=5.5
+        // 9 > 5.5 → true
+        DefGreater(Symmetric(10, 0.1), Symmetric(5, 0.1))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DefinitelyGreaterThan_IntervalsOverlap_IsFalse()
+    {
+        // Lhs: 10 ± 10% → lower=9;  Rhs: 9 ± 10% → upper=9.9
+        // 9 > 9.9 → false
+        DefGreater(Symmetric(10, 0.1), Symmetric(9, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void DefinitelyGreaterThan_AsymmetricBounds_UsesDirectionalErrors()
+    {
+        // Lhs: 10 kg, lowerError=1 → lower=9;  Rhs: 5 kg, upperError=3 → upper=8
+        // 9 > 8 → true
+        DefGreater(Asymmetric(10, 0.5, 1.0), Asymmetric(5, 3.0, 0.5))
+            .IsSatisfied().Should().BeTrue();
+
+        // Rhs: 5 kg, upperError=4 → upper=9
+        // 9 > 9 → false (strict)
+        DefGreater(Asymmetric(10, 0.5, 1.0), Asymmetric(5, 4.0, 0.5))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    // ── LowerBoundsGreaterThanOperator (>v) ──────────────────────────────────
+    // Lhs.Lower > Rhs.Lower: floors compared; intervals may overlap
+
+    [Fact]
+    public void LowerBoundsGreaterThan_OverlappingIntervals_CanBeTrue()
+    {
+        // Lhs: 10 ± 10% → lower=9;  Rhs: 9 ± 10% → lower=8.1
+        // intervals overlap ([9,11] vs [8.1,9.9]), but 9 > 8.1 → true
+        LowerGreater(Symmetric(10, 0.1), Symmetric(9, 0.1))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void LowerBoundsGreaterThan_LhsLowerBelowRhsLower_IsFalse()
+    {
+        // Lhs: 9 ± 10% → lower=8.1;  Rhs: 10 ± 10% → lower=9
+        // 8.1 > 9 → false
+        LowerGreater(Symmetric(9, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void LowerBoundsGreaterThan_IsWeakerThanDefinitely()
+    {
+        // Lhs: 10 ± 10%, Rhs: 9 ± 10%
+        // DefinitelyGreaterThan: Lhs.lower=9 > Rhs.upper=9.9 → false
+        // LowerBoundsGreaterThan: Lhs.lower=9 > Rhs.lower=8.1 → true
+        var lhs = Symmetric(10, 0.1);
+        var rhs = Symmetric(9, 0.1);
+        DefGreater(lhs, rhs).IsSatisfied().Should().BeFalse();
+        LowerGreater(lhs, rhs).IsSatisfied().Should().BeTrue();
+    }
+
+    // ── NominallyGreaterThanOperator (>~) ────────────────────────────────────
+    // Lhs.KmsValue > Rhs.KmsValue: nominal values only, uncertainty ignored
+
+    [Fact]
+    public void NominallyGreaterThan_LargeOverlappingErrors_IgnoresUncertainty()
+    {
+        NomGreater(Symmetric(10, 0.5), Symmetric(9, 0.5))
+            .IsSatisfied().Should().BeTrue();
+    }
+
+    [Fact]
+    public void NominallyGreaterThan_NominalReversed_IsFalse()
+    {
+        NomGreater(Symmetric(9, 0), Symmetric(10, 0))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    [Fact]
+    public void NominallyGreaterThan_EqualNominals_IsFalse()
+    {
+        NomGreater(Symmetric(10, 0.1), Symmetric(10, 0.1))
+            .IsSatisfied().Should().BeFalse();
+    }
+
+    // ── Less/Greater symmetry ─────────────────────────────────────────────────
+    // LessThan(a, b) should equal GreaterThan(b, a) for each strictness level
+
+    [Theory]
+    [InlineData(5.0, 10.0)]
+    [InlineData(10.0, 5.0)]
+    [InlineData(10.0, 10.0)]
+    public void DefinitelyLessThan_MatchesDefinitelyGreaterThanWithSwappedArgs(double a, double b)
+    {
+        DefLess(Symmetric(a, 0.1), Symmetric(b, 0.1)).IsSatisfied()
+            .Should().Be(DefGreater(Symmetric(b, 0.1), Symmetric(a, 0.1)).IsSatisfied());
+    }
+
+    [Theory]
+    [InlineData(9.0, 10.0)]
+    [InlineData(11.0, 10.0)]
+    public void UpperBoundsLessThan_MatchesLowerBoundsGreaterThanWithSwappedArgs(double a, double b)
+    {
+        UpperLess(Symmetric(a, 0.1), Symmetric(b, 0.1)).IsSatisfied()
+            .Should().Be(LowerGreater(Symmetric(b, 0.1), Symmetric(a, 0.1)).IsSatisfied());
+    }
+
+    [Theory]
+    [InlineData(5.0, 10.0)]
+    [InlineData(10.0, 5.0)]
+    [InlineData(10.0, 10.0)]
+    public void NominallyLessThan_MatchesNominallyGreaterThanWithSwappedArgs(double a, double b)
+    {
+        NomLess(Symmetric(a, 0.1), Symmetric(b, 0.1)).IsSatisfied()
+            .Should().Be(NomGreater(Symmetric(b, 0.1), Symmetric(a, 0.1)).IsSatisfied());
+    }
+}

--- a/DimensionedExpression/BinaryOperators/InequalityOperators.cs
+++ b/DimensionedExpression/BinaryOperators/InequalityOperators.cs
@@ -1,0 +1,127 @@
+using DimensionedExpression.BaseModels;
+
+namespace DimensionedExpression.BinaryOperators;
+
+/// <summary>
+/// Satisfied when the entire Lhs uncertainty interval lies strictly below the entire Rhs uncertainty
+/// interval — i.e. Lhs.Upper &lt; Rhs.Lower. No overlap between the two intervals is permitted.
+/// Symbol: &lt;&lt;
+/// Use for definitive less-than checks where even worst-case Lhs must remain below best-case Rhs.
+/// </summary>
+public class DefinitelyLessThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => "<<";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        var lhs = Lhs.Value!;
+        var rhs = Rhs.Value!;
+        return lhs.KmsValue + lhs.KmsUpperAbsoluteError < rhs.KmsValue - rhs.KmsLowerAbsoluteError;
+    }
+}
+
+/// <summary>
+/// Satisfied when the upper bound of Lhs is strictly less than the upper bound of Rhs — i.e.
+/// Lhs.Upper &lt; Rhs.Upper. The intervals may overlap; this is a weaker check than
+/// <see cref="DefinitelyLessThanOperator"/>.
+/// Symbol: &lt;^
+/// Use when you need to know that Lhs's worst-case high value is bounded by Rhs's worst-case high value.
+/// </summary>
+public class UpperBoundsLessThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => "<^";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        var lhs = Lhs.Value!;
+        var rhs = Rhs.Value!;
+        return lhs.KmsValue + lhs.KmsUpperAbsoluteError < rhs.KmsValue + rhs.KmsUpperAbsoluteError;
+    }
+}
+
+/// <summary>
+/// Satisfied when the nominal (center) Lhs value is strictly less than the nominal Rhs value.
+/// Uncertainty is ignored entirely.
+/// Symbol: &lt;~
+/// Use when only the reported values matter and measurement uncertainty is not part of the check.
+/// </summary>
+public class NominallyLessThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => "<~";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        return Lhs.Value!.KmsValue < Rhs.Value!.KmsValue;
+    }
+}
+
+/// <summary>
+/// Satisfied when the entire Lhs uncertainty interval lies strictly above the entire Rhs uncertainty
+/// interval — i.e. Lhs.Lower &gt; Rhs.Upper. No overlap between the two intervals is permitted.
+/// Symbol: &gt;&gt;
+/// Use for definitive greater-than checks where even worst-case Lhs must remain above best-case Rhs.
+/// </summary>
+public class DefinitelyGreaterThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => ">>";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        var lhs = Lhs.Value!;
+        var rhs = Rhs.Value!;
+        return lhs.KmsValue - lhs.KmsLowerAbsoluteError > rhs.KmsValue + rhs.KmsUpperAbsoluteError;
+    }
+}
+
+/// <summary>
+/// Satisfied when the lower bound of Lhs is strictly greater than the lower bound of Rhs — i.e.
+/// Lhs.Lower &gt; Rhs.Lower. The intervals may overlap; this is a weaker check than
+/// <see cref="DefinitelyGreaterThanOperator"/>.
+/// Symbol: &gt;v
+/// Use when you need to know that Lhs's worst-case low value is above Rhs's worst-case low value.
+/// </summary>
+public class LowerBoundsGreaterThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => ">v";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        var lhs = Lhs.Value!;
+        var rhs = Rhs.Value!;
+        return lhs.KmsValue - lhs.KmsLowerAbsoluteError > rhs.KmsValue - rhs.KmsLowerAbsoluteError;
+    }
+}
+
+/// <summary>
+/// Satisfied when the nominal (center) Lhs value is strictly greater than the nominal Rhs value.
+/// Uncertainty is ignored entirely.
+/// Symbol: &gt;~
+/// Use when only the reported values matter and measurement uncertainty is not part of the check.
+/// </summary>
+public class NominallyGreaterThanOperator : NonCommutativeOperatorBase
+{
+    public override string Symbol => ">~";
+
+    public override bool? IsSatisfied()
+    {
+        if (Lhs.IsFullyDescribed is false || Rhs.IsFullyDescribed is false)
+            return null;
+
+        return Lhs.Value!.KmsValue > Rhs.Value!.KmsValue;
+    }
+}

--- a/DimensionedExpression/BinaryOperators/OPERATORS.md
+++ b/DimensionedExpression/BinaryOperators/OPERATORS.md
@@ -1,0 +1,69 @@
+# Binary Operator Taxonomy
+
+All operators evaluate `IsSatisfied()` → `bool?` (returns `null` when either side is unbound).
+
+Interval notation: for a `PrecisionQuantity` *v*, its uncertainty interval is
+`[v.KmsValue − v.KmsLowerAbsoluteError, v.KmsValue + v.KmsUpperAbsoluteError]`.
+
+---
+
+## Equality
+
+| Class | Symbol | Commutative | Condition |
+| --- | --- | --- | --- |
+| `EqualityOperator` | `==` | ✓ | `IEqualityEstimating.AreEqual(Lhs, Rhs)` — injected strategy |
+
+---
+
+## Tolerance operators
+
+These ask "are two measurements compatible within their uncertainties?" rather than
+asserting an ordering.
+
+| Class | Symbol | Commutative | Condition |
+| --- | --- | --- | --- |
+| `MutuallyWithinToleranceOperator` | `≃` | ✓ | Each nominal value falls inside the other's interval: `Lhs ∈ Rhs.interval` AND `Rhs ∈ Lhs.interval` |
+| `AnyToleranceOverlapOperator` | `≈` | ✓ | The two intervals overlap at all: `smaller.Upper > bigger.Lower` |
+| `WhollyWithinToleranceOperator` | `[=}` | ✗ | Lhs interval is strictly inside Rhs interval: `Lhs.Lower > Rhs.Lower` AND `Lhs.Upper < Rhs.Upper` |
+| `WithinBindingToleranceOperator` | `=}` | ✗ | Lhs nominal value is inside Rhs interval: `Rhs.Lower < Lhs.KmsValue < Rhs.Upper` |
+| `PointAndUpperBoundWithinToleranceOperator` | `[≓}` | ✗ | Lhs nominal value and upper bound are both inside Rhs interval |
+| `PointAndLowerBoundWithinToleranceOperator` | `[≒}` | ✗ | Lhs nominal value and lower bound are both inside Rhs interval |
+
+---
+
+## Inequality operators
+
+These assert an ordering between two measurements, with three levels of strictness
+for each direction. All are non-commutative (Lhs = value under test, Rhs = bound).
+
+No `≤` / `≥` variants exist — floating-point equality is unreachable in practice.
+
+### Less-than (`<`)
+
+| Class | Symbol | Condition |
+| --- | --- | --- |
+| `DefinitelyLessThanOperator` | `<<` | `Lhs.Upper < Rhs.Lower` — entire intervals non-overlapping; Lhs is certainly less |
+| `UpperBoundsLessThanOperator` | `<^` | `Lhs.Upper < Rhs.Upper` — ceiling of Lhs below ceiling of Rhs; intervals may overlap |
+| `NominallyLessThanOperator` | `<~` | `Lhs.KmsValue < Rhs.KmsValue` — nominal values only; uncertainty ignored |
+
+### Greater-than (`>`)
+
+| Class | Symbol | Condition |
+| --- | --- | --- |
+| `DefinitelyGreaterThanOperator` | `>>` | `Lhs.Lower > Rhs.Upper` — entire intervals non-overlapping; Lhs is certainly greater |
+| `LowerBoundsGreaterThanOperator` | `>v` | `Lhs.Lower > Rhs.Lower` — floor of Lhs above floor of Rhs; intervals may overlap |
+| `NominallyGreaterThanOperator` | `>~` | `Lhs.KmsValue > Rhs.KmsValue` — nominal values only; uncertainty ignored |
+
+---
+
+## Choosing the right operator
+
+```
+Need exact equality?                 → EqualityOperator
+Need compatibility within errors?    → MutuallyWithinTolerance / AnyToleranceOverlap
+Need one interval contained by another?  → WhollyWithinTolerance / WithinBindingTolerance
+Need one interval ≈ but anchored?    → PointAndUpperBound / PointAndLowerBound
+Need strict ordering (no overlap)?   → DefinitelyLessThan / DefinitelyGreaterThan
+Need ordering at worst-case bound?   → UpperBoundsLessThan / LowerBoundsGreaterThan
+Need ordering of nominal values only? → NominallyLessThan / NominallyGreaterThan
+```

--- a/project-plan.md
+++ b/project-plan.md
@@ -34,35 +34,35 @@ Goal: get the codebase into a clean, consistent state before building new featur
 
 ---
 
-### Milestone 1.5 — Unit Library Completion
+### Milestone 1.5 — Unit Library Completion ✅ *complete*
 
 Goal: flesh out the unit library to cover the most common engineering domains before work begins on the expression layer.
 
 **Mechanical:**
 
-- [ ] `Torque` — N·m, lbf·ft, lbf·in (same dimensions as Energy; separate class for semantic clarity)
-- [ ] `Momentum` — kg·m/s, lbf·s (M·L·t⁻¹; impulse has the same dimensions, can live here)
-- [ ] `SurfaceTension` — N/m (M·t⁻²)
-- [ ] `SpecificEnergy` — J/kg, BTU/lb, kWh/kg (L²·t⁻²; relevant for fuels, batteries, explosives)
+- [x] `Torque` — N·m, lbf·ft, lbf·in (same dimensions as Energy; separate class for semantic clarity)
+- [x] `Momentum` — kg·m/s, lbf·s (M·L·t⁻¹; impulse has the same dimensions, can live here)
+- [x] `SurfaceTension` — N/m (M·t⁻²)
+- [x] `SpecificEnergy` — J/kg, BTU/lb, kWh/kg (L²·t⁻²; relevant for fuels, batteries, explosives)
 
 **Fluid / Thermal:**
 
-- [ ] `DynamicViscosity` — Pa·s, cP (centipoise), poise (M·L⁻¹·t⁻¹)
-- [ ] `KinematicViscosity` — m²/s, cSt (centistoke), St (L²·t⁻¹)
-- [ ] `ThermalConductivity` — W/(m·K) (M·L·t⁻³·T⁻¹)
-- [ ] `SpecificHeatCapacity` — J/(kg·K) (L²·t⁻²·T⁻¹)
-- [ ] `HeatTransferCoefficient` — W/(m²·K) (M·t⁻³·T⁻¹)
+- [x] `DynamicViscosity` — Pa·s, cP (centipoise), poise (M·L⁻¹·t⁻¹)
+- [x] `KinematicViscosity` — m²/s, cSt (centistoke), St (L²·t⁻¹)
+- [x] `ThermalConductivity` — W/(m·K) (M·L·t⁻³·T⁻¹)
+- [x] `SpecificHeatCapacity` — J/(kg·K) (L²·t⁻²·T⁻¹)
+- [x] `HeatTransferCoefficient` — W/(m²·K) (M·t⁻³·T⁻¹)
 
 **Electrical:**
 
-- [ ] `ElectricCapacitance` — F, µF, nF, pF (A²·s⁴·M⁻¹·L⁻²)
-- [ ] `ElectricInductance` — H, mH, µH, nH (M·L²·A⁻²·t⁻²)
-- [ ] `ElectricConductance` — S (Siemens = 1/Ω) (A²·t³·M⁻¹·L⁻²)
+- [x] `ElectricCapacitance` — F, µF, nF, pF (A²·s⁴·M⁻¹·L⁻²)
+- [x] `ElectricInductance` — H, mH, µH, nH (M·L²·A⁻²·t⁻²)
+- [x] `ElectricConductance` — S (Siemens = 1/Ω) (A²·t³·M⁻¹·L⁻²)
 
 **Electromagnetic:**
 
-- [ ] `MagneticFluxDensity` — T (Tesla), G (Gauss) (M·t⁻²·I⁻¹)
-- [ ] `MagneticFlux` — Wb (Weber) (M·L²·t⁻²·I⁻¹)
+- [x] `MagneticFluxDensity` — T (Tesla), G (Gauss) (M·t⁻²·I⁻¹)
+- [x] `MagneticFlux` — Wb (Weber) (M·L²·t⁻²·I⁻¹)
 
 ---
 
@@ -78,6 +78,31 @@ Goal: close the gaps in `DimensionedExpression` so the expression system is full
 
 ---
 
+### Milestone 2.5 — Inequality Operators
+
+Goal: extend the `BinaryOperators` namespace with uncertainty-aware ordering operators and document the full operator taxonomy.
+
+No `≤` / `≥` variants — floating point equality is essentially unreachable in practice; callers who need "at most" can negate the other side.
+
+**`<` operators (non-commutative; Lhs = value under test, Rhs = bound):**
+
+- [ ] `DefinitelyLessThanOperator` — `Lhs.Upper < Rhs.Lower`: the entire Lhs interval is strictly below the entire Rhs interval; no overlap possible
+- [ ] `UpperBoundsLessThanOperator` — `Lhs.Upper < Rhs.Upper`: the ceiling of Lhs is below the ceiling of Rhs; intervals may overlap
+- [ ] `NominallyLessThanOperator` — `Lhs.KmsValue < Rhs.KmsValue`: point comparison only; uncertainty ignored
+
+**`>` operators** (symmetric to `<`; lower bounds drive the checks):
+
+- [ ] `DefinitelyGreaterThanOperator` — `Lhs.Lower > Rhs.Upper`
+- [ ] `LowerBoundsGreaterThanOperator` — `Lhs.Lower > Rhs.Lower`
+- [ ] `NominallyGreaterThanOperator` — `Lhs.KmsValue > Rhs.KmsValue`
+
+**Documentation and tests:**
+
+- [ ] Add `DimensionedExpression/BinaryOperators/OPERATORS.md` — a taxonomy table covering all operators (equality, the six tolerance operators from M2, and the six inequality operators above), with a one-line geometric description and the exact interval condition for each
+- [ ] Unit tests in `DimensionedExpression.Test` covering all six operators (symmetric and asymmetric uncertainty, boundary conditions, null returns for unbound expressions)
+
+---
+
 ### Milestone 3 — Evaluation Engine *(the payoff)*
 
 Goal: given a populated `ExpressionSystem`, compute everything that can be computed and report constraint satisfaction.
@@ -86,6 +111,8 @@ Goal: given a populated `ExpressionSystem`, compute everything that can be compu
 - [ ] Run all constraints (`Definitions` and `Constraints` lists) and report pass/fail with actual vs. expected values
 - [ ] Surface a clean result model (which expressions resolved, which constraints passed/failed, which variables are still missing)
 - [ ] Add conversion factor provenance to `UnitOfMeasure` — a structured `ConversionSource` record carrying the standard name (e.g. "NIST SP 811"), URL, and year for non-trivial factors like lb→kg or BTU→J. Include provenance in the serialization DTOs so exported calculations carry a full audit trail of where their conversion factors came from.
+- [ ] Add `ExponentialExpression(argument: IExpression)` — unary expression computing `e^x`; requires argument to be dimensionless; result is dimensionless; uncertainty: `RelativeError(exp(x)) ≈ |x| · RelativeError(x)`
+- [ ] Add `NaturalLogExpression(argument: IExpression)` — unary expression computing `ln(x)`; requires argument to be dimensionless and positive; result is dimensionless; uncertainty: `AbsoluteError(ln(x)) ≈ RelativeError(x)`; primary motivation is Arrhenius equations (`k = A · exp(-Eₐ / (R·T))`)
 
 ---
 
@@ -99,6 +126,15 @@ Goal: given a system with some unknowns, determine if it is solvable and solve i
 - [ ] `DegreesOfFreedom()` (from Milestone 2) becomes the gate: DoF == 0 → evaluate; DoF == 1 → solve; DoF > 1 → report which variables are needed
 - [ ] Implement a basic solver for product/quotient/sum relationships (the linear and multiplicative cases are tractable without a CAS)
 - [ ] Leave the door open for a symbolic or numeric solver as a future plugin
+
+---
+
+### Milestone 5 — Wishlist *(scope not yet committed)*
+
+These features are worth designing for but intentionally deferred until M4 is solid.
+
+- [ ] **Complex number support** — A `ComplexExpression` type holding `Re : IExpression` and `Im : IExpression` children, supporting complex arithmetic (add, multiply, divide, conjugate). Exposes `.Magnitude()` → `sqrt(Re² + Im²)` and `.Phase()` → `atan2(Im, Re)` as regular `IExpression` nodes. Never promotes directly to `PhysicalQuantity`; callers must extract a real component. Primary motivation: AC circuit analysis with phasor impedance.
+- [ ] **Binary exponentiation** — `PowerExpression(base: IExpression, exponent: IExpression)`. Exponent must be dimensionless (and ideally a rational constant for dimensional analysis to remain tractable). Dimensionality of result = base dimensionality raised to the exponent. Uncertainty: standard power-rule propagation. Complements `ExponentialExpression` (`e^x`) from M3 for general `x^n` expressions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds 6 inequality operators to `DimensionedExpression/BinaryOperators/` — three strictness levels for each of `<` and `>`:
  - `DefinitelyLessThan` / `DefinitelyGreaterThan` (`<<` / `>>`) — entire intervals non-overlapping
  - `UpperBoundsLessThan` / `LowerBoundsGreaterThan` (`<^` / `>v`) — ceiling/floor comparison; intervals may overlap
  - `NominallyLessThan` / `NominallyGreaterThan` (`<~` / `>~`) — point values only, uncertainty ignored
- No `≤` / `≥` variants — floating-point equality is unreachable in practice
- All operators use `KmsUpperAbsoluteError` / `KmsLowerAbsoluteError` directionally, consistent with the M2 tolerance operators
- Adds `OPERATORS.md` taxonomy table covering all ~13 binary operators with exact interval conditions and a quick decision guide
- 29 new unit tests (76 total in `DimensionedExpression.Test`): null returns, true/false cases, asymmetric uncertainty, "weaker than" relationship between strictness levels, and less/greater symmetry property

## Test plan

- [ ] All 76 `DimensionedExpression.Test` tests pass (`dotnet test`)
- [ ] Full solution builds clean (`dotnet build Calcusystem.sln`)
- [ ] Review `OPERATORS.md` decision guide for accuracy
- [ ] Review asymmetric bound handling in `DefinitelyLessThanOperator` and `DefinitelyGreaterThanOperator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)